### PR TITLE
解决私域包发布umd时报错问题

### DIFF
--- a/commands/publish.js
+++ b/commands/publish.js
@@ -112,12 +112,12 @@ const buildSystemMin = () => new Promise((resolve, reject) => {
 
 const upload = async () => {
   console.log('开始发布CDN');
-  const { name, version } = pkgOption;
+  const { version } = pkgOption;
   if (!OSS_TOKEN) {
     throw 'OSS_TOKEN错误，请执行 cook config进行配置';
   }
   const umdFolderPath = path.join(process.cwd(), 'library/umd');
-  const result = await choiceUpload.umd(name, version, umdFolderPath, OSS_TOKEN);
+  const result = await choiceUpload.umd(filename, version, umdFolderPath, OSS_TOKEN);
   console.log(result);
   return result;
 }

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -117,7 +117,7 @@ const upload = async () => {
   if (!OSS_TOKEN) {
     throw 'OSS_TOKEN错误，请执行 cook config进行配置';
   }
-  const umdFolderPath = path.join(process.cwd(), 'library/umd');
+  const umdFolderPath = path.join(process.cwd(), 'library');
   const result = await choiceUpload.umd(appName, version, umdFolderPath, OSS_TOKEN);
   console.log(result);
   return result;

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -112,12 +112,13 @@ const buildSystemMin = () => new Promise((resolve, reject) => {
 
 const upload = async () => {
   console.log('开始发布CDN');
-  const { version } = pkgOption;
+  const { name, version } = pkgOption;
+  const appName = name.indexOf('/') > -1 ? name.split('/')[1] : name; // 对name处理，去掉私域标识
   if (!OSS_TOKEN) {
     throw 'OSS_TOKEN错误，请执行 cook config进行配置';
   }
   const umdFolderPath = path.join(process.cwd(), 'library/umd');
-  const result = await choiceUpload.umd(filename, version, umdFolderPath, OSS_TOKEN);
+  const result = await choiceUpload.umd(appName, version, umdFolderPath, OSS_TOKEN);
   console.log(result);
   return result;
 }


### PR DESCRIPTION
解决辰森私域包发布umd时路径问题，原因是私域包的package.josn内的name值包含/字符，导致上传脚本解析路径时出错，建议使用appConfig内配置的filename作为appName传入上传脚本